### PR TITLE
Upload proguard mapping.txt files on Android releases

### DIFF
--- a/configure
+++ b/configure
@@ -13,11 +13,22 @@ sanity_check () {
             echo "Can't find virtualenv, install that first: sudo pip install virtualenv"
             exit 1
             )
+
+    which brew >/dev/null \
+        || which sentry-cli >/dev/null \
+        || (
+            echo "Can't find brew or sentry-cli, install either to continue"
+            exit 1
+            )
 }
 
 install_python_deps () {
     test -d venv || virtualenv venv -p $(which python3)
     ./venv/bin/pip install -r requirements.txt
+}
+
+install_sentry_cli () {
+    brew install getsentry/tools/sentry-cli
 }
 
 main

--- a/tools/release_android.py
+++ b/tools/release_android.py
@@ -350,24 +350,24 @@ def _checkout_repository(url, directory, branch):
         '--quiet',
     ])
 
+
 def upload_proguard_mappings(version):
     flavors = {
-            'prod': 'Android',
-            'unity': 'Unity',
-            }
+        'prod': 'Android',
+        'unity': 'Unity',
+    }
     namespace = uuid.uuid5(uuid.NAMESPACE_DNS, 'megacool.co')
-    for flavor,platform in flavors.items():
-        mapping_uuid = uuid.uuid5(namespace, '%s/%s' % (str(version), platform))
-        manifest_path = 'megacool/build/intermediates/manifests/full/%s/release/AndroidManifest.xml' % (flavor)
-        mapping_path = 'megacool/build/outputs/mapping/%s/release/mapping.txt' % (flavor)
+    for flavor, platform in flavors.items():
+        mapping_uuid = uuid.uuid5(namespace, '%s/%s' % (version, platform))
+        manifest_path = 'megacool/build/intermediates/manifests/full/%s/release/AndroidManifest.xml' % flavor
+        mapping_path = 'megacool/build/outputs/mapping/%s/release/mapping.txt' % flavor
         subprocess.check_call([
             'sentry-cli',
             'upload-proguard',
             '--android-manifest', manifest_path,
             '--uuid', mapping_uuid,
             mapping_path,
-            ])
-
+        ])
 
 
 def get_args():


### PR DESCRIPTION
I couldn't test this myself as I don't actually have the mapping files for the production releases but fingers crossed it's all good. You'll probably need to run `sentry-cli login` first, and you can download the cli through `npm` via `sudo npm install -g @sentry/cli` or `curl` with `curl -sL https://sentry.io/get-cli/ | bash`